### PR TITLE
added ibm_is_placement_group

### DIFF
--- a/docs/ibmcloud.md
+++ b/docs/ibmcloud.md
@@ -83,6 +83,7 @@ List of supported IBM Cloud resources:
     * `ibm_is_vpc_routing_table_route`
 *   `ibm_is_subnet`
 *   `ibm_is_instance`
+*   `ibm_is_placement_group`
 * `ibm_is_security_group`
     * `ibm_is_security_group`
     * `ibm_is_security_group_rule`

--- a/providers/ibm/ibm_provider.go
+++ b/providers/ibm/ibm_provider.go
@@ -134,6 +134,7 @@ func (p *IBMProvider) GetSupportedService() map[string]terraformutils.ServiceGen
 		"ibm_is_vpc_address_prefix":         &VPCAddressPrefixGenerator{},
 		"ibm_is_vpc_route":                  &VPCRouteGenerator{},
 		"ibm_is_vpc_routing_table":          &VPCRoutingTableGenerator{},
+		"ibm_is_placement_group":            &PlacementGroupGenerator{},
 		"ibm_is_subnet":                     &SubnetGenerator{},
 		"ibm_is_instance":                   &InstanceGenerator{},
 		"ibm_is_security_group":             &SecurityGroupGenerator{},


### PR DESCRIPTION
Cat is_placement_group.tf

```
resource "ibm_is_placement_group" "tfer--adya_test_placement_group" {
  name           = "adya-test-placement-group"
  resource_group = "834d7f416f2740f49dd7d2c2c7073253"
  strategy       = "host_spread"
}

resource "ibm_is_placement_group" "tfer--test_placement_group" {
  name           = "test-placement-group"
  resource_group = "834d7f416f2740f49dd7d2c2c7073253"
  strategy       = "host_spread"
}
```
Created the placement group(adya-test-placement-group) using generated terraformer tf files and again generated the files to capture the newly created placement group.
Able to delete through tf files.
