### PR TITLE
Added kp_key_alias and kp_key_policies

### DIFF
--- a/providers/ibm/ibm_kp.go
+++ b/providers/ibm/ibm_kp.go
@@ -65,6 +65,44 @@ func (g KPGenerator) loadkPKeys() func(kpKeyCRN, kpKeyName string, dependsOn []s
 	}
 }
 
+func (g KPGenerator) loadkPKeyAliases() func(kpKeyCRN, kpKeyAlias string, dependsOn []string) terraformutils.Resource {
+	names := make(map[string]struct{})
+	random := true
+	return func(kpKeyCRN, kpKeyAlias string, dependsOn []string) terraformutils.Resource {
+		names, random = getRandom(names, kpKeyAlias, random)
+		resource := terraformutils.NewResource(
+			fmt.Sprintf("%s:alias:%s", kpKeyAlias, kpKeyCRN),
+			normalizeResourceName(kpKeyAlias, random),
+			"ibm_kms_key_alias",
+			"ibm",
+			map[string]string{},
+			[]string{},
+			map[string]interface{}{
+				"depends_on": dependsOn,
+			})
+		return resource
+	}
+}
+
+func (g KPGenerator) loadKpKeyPolicies() func(kpKeyCRN string, dependsOn []string) terraformutils.Resource {
+	names := make(map[string]struct{})
+	random := true
+	return func(kpKeyCRN string, dependsOn []string) terraformutils.Resource {
+		names, random = getRandom(names, kpKeyCRN, random)
+		resource := terraformutils.NewResource(
+			kpKeyCRN,
+			normalizeResourceName("kp_policies", random),
+			"ibm_kms_key_policies",
+			"ibm",
+			map[string]string{},
+			[]string{},
+			map[string]interface{}{
+				"depends_on": dependsOn,
+			})
+		return resource
+	}
+}
+
 func (g *KPGenerator) InitResources() error {
 	region := g.Args["region"].(string)
 	bmxConfig := &bluemix.Config{
@@ -123,9 +161,68 @@ func (g *KPGenerator) InitResources() error {
 			dependsOn = append(dependsOn,
 				"ibm_resource_instance."+resourceName)
 			g.Resources = append(g.Resources, fnObjt(key.CRN, key.Name, dependsOn))
-		}
+			resourceName := g.Resources[len(g.Resources)-1:][0].ResourceName
 
+			fnObjt := g.loadkPKeyAliases()
+			dependsOn = append(dependsOn,
+				"ibm_kms_key."+resourceName)
+			for _, alias := range key.Aliases {
+				g.Resources = append(g.Resources, fnObjt(key.CRN, alias, dependsOn))
+			}
+
+			policies, _ := client.GetPolicies(context.Background(), key.ID)
+			funObjt := g.loadKpKeyPolicies()
+			for range policies {
+				g.Resources = append(g.Resources, funObjt(key.CRN, dependsOn))
+			}
+		}
+	}
+	return nil
+}
+
+func (g *KPGenerator) PostConvertHook() error {
+	for i, rk := range g.Resources {
+		if rk.InstanceInfo.Type != "ibm_kms_key" {
+			continue
+		}
+		for _, ri := range g.Resources {
+			if ri.InstanceInfo.Type != "ibm_resource_instance" {
+				continue
+			}
+			if rk.InstanceState.Attributes["instance_id"] == ri.InstanceState.Attributes["guid"] {
+				g.Resources[i].Item["instance_id"] = "${ibm_resource_instance." + ri.ResourceName + ".guid}"
+			}
+		}
 	}
 
+	for i, ra := range g.Resources {
+		if ra.InstanceInfo.Type != "ibm_kms_key_alias" {
+			continue
+		}
+		for _, rk := range g.Resources {
+			if rk.InstanceInfo.Type != "ibm_kms_key" {
+				continue
+			}
+			if ra.InstanceState.Attributes["instance_id"] == rk.InstanceState.Attributes["instance_id"] && ra.InstanceState.Attributes["key_id"] == rk.InstanceState.Attributes["key_id"] {
+				g.Resources[i].Item["instance_id"] = "${ibm_kms_key." + rk.ResourceName + ".instance_id}"
+				g.Resources[i].Item["key_id"] = "${ibm_kms_key." + rk.ResourceName + ".key_id}"
+			}
+		}
+	}
+
+	for i, rp := range g.Resources {
+		if rp.InstanceInfo.Type != "ibm_kms_key_policies" {
+			continue
+		}
+		for _, rk := range g.Resources {
+			if rk.InstanceInfo.Type != "ibm_kms_key" {
+				continue
+			}
+			if rp.InstanceState.Attributes["instance_id"] == rk.InstanceState.Attributes["instance_id"] && rp.InstanceState.Attributes["key_id"] == rk.InstanceState.Attributes["key_id"] {
+				g.Resources[i].Item["instance_id"] = "${ibm_kms_key." + rk.ResourceName + ".instance_id}"
+				g.Resources[i].Item["key_id"] = "${ibm_kms_key." + rk.ResourceName + ".key_id}"
+			}
+		}
+	}
 	return nil
 }

--- a/providers/ibm/ibm_kp.go
+++ b/providers/ibm/ibm_kp.go
@@ -66,13 +66,10 @@ func (g KPGenerator) loadkPKeys() func(kpKeyCRN, kpKeyName string, dependsOn []s
 }
 
 func (g KPGenerator) loadkPKeyAliases() func(kpKeyCRN, kpKeyAlias string, dependsOn []string) terraformutils.Resource {
-	names := make(map[string]struct{})
-	random := true
 	return func(kpKeyCRN, kpKeyAlias string, dependsOn []string) terraformutils.Resource {
-		names, random = getRandom(names, kpKeyAlias, random)
 		resource := terraformutils.NewResource(
 			fmt.Sprintf("%s:alias:%s", kpKeyAlias, kpKeyCRN),
-			normalizeResourceName(kpKeyAlias, random),
+			normalizeResourceName(kpKeyAlias, true),
 			"ibm_kms_key_alias",
 			"ibm",
 			map[string]string{},
@@ -85,13 +82,10 @@ func (g KPGenerator) loadkPKeyAliases() func(kpKeyCRN, kpKeyAlias string, depend
 }
 
 func (g KPGenerator) loadKpKeyPolicies() func(kpKeyCRN string, dependsOn []string) terraformutils.Resource {
-	names := make(map[string]struct{})
-	random := true
 	return func(kpKeyCRN string, dependsOn []string) terraformutils.Resource {
-		names, random = getRandom(names, kpKeyCRN, random)
 		resource := terraformutils.NewResource(
 			kpKeyCRN,
-			normalizeResourceName("kp_policies", random),
+			normalizeResourceName("kp_policies", true),
 			"ibm_kms_key_policies",
 			"ibm",
 			map[string]string{},
@@ -155,6 +149,7 @@ func (g *KPGenerator) InitResources() error {
 		if err != nil {
 			return err
 		}
+
 		fnObjt := g.loadkPKeys()
 		for _, key := range output.Keys {
 			var dependsOn []string
@@ -185,10 +180,12 @@ func (g *KPGenerator) PostConvertHook() error {
 		if rk.InstanceInfo.Type != "ibm_kms_key" {
 			continue
 		}
+
 		for _, ri := range g.Resources {
 			if ri.InstanceInfo.Type != "ibm_resource_instance" {
 				continue
 			}
+
 			if rk.InstanceState.Attributes["instance_id"] == ri.InstanceState.Attributes["guid"] {
 				g.Resources[i].Item["instance_id"] = "${ibm_resource_instance." + ri.ResourceName + ".guid}"
 			}


### PR DESCRIPTION
cat resource_instance.tf 
```
resource "ibm_resource_instance" "tfer--adya_key_protect_fpll" {
  location          = "ca-tor"
  name              = "adya-key-protect"
  plan              = "tiered-pricing"
  resource_group_id = "834d7f416f2740f49dd7d2c2c7073253"
  service           = "kms"
}
```
cat kms_key.tf
```
resource "ibm_kms_key" "tfer--adya_kms_key_ngzi" {
  depends_on    = ["ibm_resource_instance.tfer--adya_key_protect_fpll"]
  endpoint_type = "public"
  force_delete  = "false"
  instance_id   = "${ibm_resource_instance.tfer--adya_key_protect_fpll.guid}"
  key_name      = "adya-kms-key"
  key_ring_id   = "default"
  payload       = "ZL4m0+f8LvKqyPZ8UoqiQKssQhutGT1Six1XJ3y7xDc="
  standard_key  = "true"
}

resource "ibm_kms_key" "tfer--adya_kms_root_key_133o" {
  depends_on    = ["ibm_resource_instance.tfer--adya_key_protect_fpll"]
  endpoint_type = "public"
  force_delete  = "false"
  instance_id   = "${ibm_resource_instance.tfer--adya_key_protect_fpll.guid}"
  key_name      = "adya-kms-root-key"
  key_ring_id   = "default"
  standard_key  = "false"
}
```
cat kms_key_alias.tf 
```
resource "ibm_kms_key_alias" "tfer--adya_alias1_eyoh" {
  alias         = "adya-alias1"
  depends_on    = ["ibm_kms_key.tfer--adya_kms_key_ngzi", "ibm_resource_instance.tfer--adya_key_protect_fpll"]
  endpoint_type = "public"
  instance_id   = "${ibm_kms_key.tfer--adya_kms_key_ngzi.instance_id}"
  key_id        = "${ibm_kms_key.tfer--adya_kms_key_ngzi.key_id}"
}

resource "ibm_kms_key_alias" "tfer--adya_alias2_43e0" {
  alias         = "adya-alias2"
  depends_on    = ["ibm_kms_key.tfer--adya_kms_key_ngzi", "ibm_resource_instance.tfer--adya_key_protect_fpll"]
  endpoint_type = "public"
  instance_id   = "${ibm_kms_key.tfer--adya_kms_key_ngzi.instance_id}"
  key_id        = "${ibm_kms_key.tfer--adya_kms_key_ngzi.key_id}"
}

resource "ibm_kms_key_alias" "tfer--adya_kms_root_key_alias_ls6k" {
  alias         = "adya-kms-root-key-alias"
  depends_on    = ["ibm_kms_key.tfer--adya_kms_root_key_133o", "ibm_resource_instance.tfer--adya_key_protect_fpll"]
  endpoint_type = "public"
  instance_id   = "${ibm_kms_key.tfer--adya_kms_root_key_133o.instance_id}"
  key_id        = "${ibm_kms_key.tfer--adya_kms_root_key_133o.key_id}"
}
```
cat kms_key_policies.tf
```
resource "ibm_kms_key_policies" "tfer--kp_policies_1hh2" {
  depends_on    = ["ibm_kms_key.tfer--adya_kms_root_key_133o", "ibm_resource_instance.tfer--adya_key_protect_fpll"]
  endpoint_type = "public"
  instance_id   = "${ibm_kms_key.tfer--adya_kms_root_key_133o.instance_id}"
  key_id        = "${ibm_kms_key.tfer--adya_kms_root_key_133o.key_id}"

  rotation {
    interval_month = "5"
  }
}
```

